### PR TITLE
add method for when you already have bitcore transaction object

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,8 @@ var fromHash = function(hash, config) {
     })
   })
 }
-var fromTx = function(transaction, options) {
+var fromGene = function(gene, options) {
   return new Promise(function(resolve, reject) {
-    let gene = new bch.Transaction(transaction);
     let t = gene.toObject()
     let result = [];
     let inputs = [];
@@ -119,7 +118,12 @@ var fromTx = function(transaction, options) {
     })
   })
 }
+var fromTx = function(transaction, options) {
+    return fromGene(new bch.Transaction(transaction), options);
+}
+
 module.exports = {
   fromHash: fromHash,
+  fromGene: fromGene,
   fromTx: fromTx
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fountainhead-tna",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Transaction Nucleic Acid",
   "main": "index.js",
   "author": "",


### PR DESCRIPTION
This is to be looked at in conjunction with bitd pr called upgrade_speed as well, this is a dependent of it. 

All this does is allow applications to pass in a bitcore-lib-cash transaction object so it doesn't have to be recreated if that already exists. 